### PR TITLE
Add Docker cleanup target (make local-infrastructure-down) to Makefile

### DIFF
--- a/apps/second-brain-offline/Makefile
+++ b/apps/second-brain-offline/Makefile
@@ -42,6 +42,8 @@ local-infrastructure-up: local-docker-infrastructure-up local-zenml-server-stop 
 
 local-infrastructure-stop: local-docker-infrastructure-stop local-zenml-server-stop
 
+local-infrastructure-down:
+	docker compose -f ../infrastructure/docker/docker-compose.yml down
 # --- AWS ---
 
 validate_aws_boto3:


### PR DESCRIPTION
### Summary
This PR adds a new Makefile target: `local-infrastructure-down`.

### Details
- The new target runs `docker compose down` to clean up local containers.
- This complements the existing `local-infrastructure-up` and `local-infrastructure-stop` commands.
- It helps developers completely shut down and remove local infrastructure for a clean state.

### Why?
This fits the tutorial workflow and is useful when rebuilding infrastructure or resolving local environment conflicts.

No other files were affected.