### PR TITLE
Add `local-infrastructure-down` target in online Makefile

### DIFF
--- a/apps/second-brain-online/Makefile
+++ b/apps/second-brain-online/Makefile
@@ -37,7 +37,8 @@ local-infrastructure-up: local-docker-infrastructure-up
 
 local-infrastructure-stop: local-docker-infrastructure-stop
 
-
+local-infrastructure-down:
+	docker compose -f ../infrastructure/docker/docker-compose.yml down
 # --- Run ---
 
 run_agent_app: check-config


### PR DESCRIPTION
### Summary
This PR updates the `Makefile` under `second-brain-online` by adding a new `local-infrastructure-down` target.

### Context
A previous PR made changes to the Makefile in `second-brain-offline`. This PR ensures the same infrastructure management capability is available in the `second-brain-online` project.

### Changes
- Added `local-infrastructure-down` target to cleanly stop Docker services:
  ```bash
  docker compose -f ../infrastructure/docker/docker-compose.yml down
