### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/apps/second-brain-offline/.env.example
+++ b/apps/second-brain-offline/.env.example
@@ -9,6 +9,12 @@ HUGGINGFACE_ACCESS_TOKEN=
 # Comet ML (starting with Lesson 4)
 COMET_API_KEY=
 
+# --- Astraflow (OpenAI-compatible, 200+ models) ---
+# Global endpoint: https://api-us-ca.umodelverse.ai/v1  Sign up: https://astraflow.ucloud-global.com
+# China endpoint:  https://api.modelverse.cn/v1          Sign up: https://astraflow.ucloud.cn
+ASTRAFLOW_API_KEY=
+ASTRAFLOW_CN_API_KEY=
+
 # --- Optional settings ---
 
 # In case you want to collect data from your personal Notion database (not used in the official course, but you can use it to extract your own Notion collections)

--- a/apps/second-brain-offline/src/second_brain_offline/config.py
+++ b/apps/second-brain-offline/src/second_brain_offline/config.py
@@ -64,6 +64,19 @@ class Settings(BaseSettings):
         default=None, description="Secret key for Notion API authentication."
     )
 
+    # --- Astraflow API Configuration ---
+    # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)
+    # Global endpoint: https://api-us-ca.umodelverse.ai/v1  |  Sign up: https://astraflow.ucloud-global.com
+    # China endpoint:  https://api.modelverse.cn/v1         |  Sign up: https://astraflow.ucloud.cn
+    ASTRAFLOW_API_KEY: str | None = Field(
+        default=None,
+        description="API key for Astraflow global endpoint (https://api-us-ca.umodelverse.ai/v1).",
+    )
+    ASTRAFLOW_CN_API_KEY: str | None = Field(
+        default=None,
+        description="API key for Astraflow China endpoint (https://api.modelverse.cn/v1).",
+    )
+
     # --- OpenAI API Configuration ---
     OPENAI_API_KEY: str = Field(
         description="API key for OpenAI service authentication.",

--- a/apps/second-brain-online/.env.example
+++ b/apps/second-brain-online/.env.example
@@ -10,6 +10,13 @@ HUGGINGFACE_ACCESS_TOKEN=
 # Comet ML (starting with Lesson 4)
 COMET_API_KEY=
 
+# --- Astraflow (OpenAI-compatible, 200+ models) ---
+# Global endpoint: https://api-us-ca.umodelverse.ai/v1  Sign up: https://astraflow.ucloud-global.com
+# China endpoint:  https://api.modelverse.cn/v1          Sign up: https://astraflow.ucloud.cn
+USE_ASTRAFLOW=False
+ASTRAFLOW_API_KEY=
+ASTRAFLOW_CN_API_KEY=
+
 # --- Optional settings ---
 
 # If you want to use the dedicated Hugging Face endpoint (starting with Lesson 4)

--- a/apps/second-brain-online/src/second_brain_online/application/agents/agents.py
+++ b/apps/second-brain-online/src/second_brain_online/application/agents/agents.py
@@ -54,11 +54,21 @@ class AgentWrapper:
             )
             summarizer_tool = OpenAISummarizerTool(stream=False)
 
-        model = LiteLLMModel(
-            model_id=settings.OPENAI_MODEL_ID,
-            api_base="https://api.openai.com/v1",
-            api_key=settings.OPENAI_API_KEY,
-        )
+        if settings.USE_ASTRAFLOW:
+            logger.warning(
+                "Using Astraflow (global endpoint) as the LLM backend: https://api-us-ca.umodelverse.ai/v1"
+            )
+            model = LiteLLMModel(
+                model_id=settings.OPENAI_MODEL_ID,
+                api_base="https://api-us-ca.umodelverse.ai/v1",
+                api_key=settings.ASTRAFLOW_API_KEY,
+            )
+        else:
+            model = LiteLLMModel(
+                model_id=settings.OPENAI_MODEL_ID,
+                api_base="https://api.openai.com/v1",
+                api_key=settings.OPENAI_API_KEY,
+            )
 
         agent = ToolCallingAgent(
             tools=[what_can_i_do, retriever_tool, summarizer_tool],

--- a/apps/second-brain-online/src/second_brain_online/application/agents/tools/summarizer.py
+++ b/apps/second-brain-online/src/second_brain_online/application/agents/tools/summarizer.py
@@ -90,10 +90,16 @@ Return the document in plain text format regardless of the original format.
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.__client = OpenAI(
-            base_url="https://api.openai.com/v1",
-            api_key=settings.OPENAI_API_KEY,
-        )
+        if settings.USE_ASTRAFLOW:
+            self.__client = OpenAI(
+                base_url="https://api-us-ca.umodelverse.ai/v1",
+                api_key=settings.ASTRAFLOW_API_KEY,
+            )
+        else:
+            self.__client = OpenAI(
+                base_url="https://api.openai.com/v1",
+                api_key=settings.OPENAI_API_KEY,
+            )
 
     @track
     def forward(self, text: str) -> str:

--- a/apps/second-brain-online/src/second_brain_online/config.py
+++ b/apps/second-brain-online/src/second_brain_online/config.py
@@ -48,6 +48,23 @@ class Settings(BaseSettings):
         description="Connection URI for the local MongoDB Atlas instance.",
     )
 
+    # --- Astraflow API Configuration ---
+    # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)
+    # Global endpoint: https://api-us-ca.umodelverse.ai/v1  |  Sign up: https://astraflow.ucloud-global.com
+    # China endpoint:  https://api.modelverse.cn/v1         |  Sign up: https://astraflow.ucloud.cn
+    USE_ASTRAFLOW: bool = Field(
+        default=False,
+        description="When True, route LLM requests to Astraflow instead of OpenAI.",
+    )
+    ASTRAFLOW_API_KEY: str | None = Field(
+        default=None,
+        description="API key for Astraflow global endpoint (https://api-us-ca.umodelverse.ai/v1).",
+    )
+    ASTRAFLOW_CN_API_KEY: str | None = Field(
+        default=None,
+        description="API key for Astraflow China endpoint (https://api.modelverse.cn/v1).",
+    )
+
     # --- OpenAI API Configuration ---
     OPENAI_API_KEY: str = Field(
         description="API key for OpenAI service authentication.",


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) (by UCloud / 优刻得) as an optional OpenAI-compatible LLM provider to both the `second-brain-online` and `second-brain-offline` apps.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is API-compatible, the integration only requires setting `base_url` + `api_key` — no new SDK or subpackage is needed.

## Changes

### `second-brain-online`
- `config.py` — adds `ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`, and `USE_ASTRAFLOW` settings
- `application/agents/agents.py` — routes `LiteLLMModel` to the Astraflow global endpoint when `USE_ASTRAFLOW=True`
- `application/agents/tools/summarizer.py` — routes `OpenAISummarizerTool` to the Astraflow global endpoint when `USE_ASTRAFLOW=True`
- `.env.example` — documents the new env vars

### `second-brain-offline`
- `config.py` — adds `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` settings
- `.env.example` — documents the new env vars

## Usage

Set the following in your `.env` file to use Astraflow:

```env
USE_ASTRAFLOW=True
ASTRAFLOW_API_KEY=your-key-here
```

The agent and summarizer will then route all requests to `https://api-us-ca.umodelverse.ai/v1` instead of OpenAI.

- Global sign-up: https://astraflow.ucloud-global.com
- China sign-up: https://astraflow.ucloud.cn